### PR TITLE
Fix type for NervesFirmwareSSH2.options()

### DIFF
--- a/lib/nerves_firmware_ssh2.ex
+++ b/lib/nerves_firmware_ssh2.ex
@@ -9,7 +9,8 @@ defmodule NervesFirmwareSSH2 do
           fwup_path: Path.t(),
           devpath: Path.t(),
           task: String.t(),
-          success_callback: mfa()
+          success_callback: mfa(),
+          subsystem: charlist()
         ]
 
   @doc """


### PR DESCRIPTION
This was just missing the `subsystem` option so dialyzer would fail if you use it.